### PR TITLE
Correct the nginx proxy port in .env

### DIFF
--- a/.env
+++ b/.env
@@ -55,7 +55,7 @@ FRONTEND_ADDR=frontend:${FRONTEND_PORT}
 
 # Nginx Proxy
 NGINX_PORT=90
-NGINX_ADDR=nginx:${FRONTEND_PORT}
+NGINX_ADDR=nginx:${NGINX_PORT}
 
 # Frontend Proxy (Envoy)
 FRONTEND_HOST=frontend


### PR DESCRIPTION
`NGINX_ADDR=nginx:${FRONTEND_ADDR}` shoud be `NGINX_ADDR=nginx:${NGINX_PORT}`.

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
