### PR TITLE
fix: Fixed trace analytics and logs via Data-Prepper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-version: '3.9'
+version: "3.9"
 x-default-logging: &logging
   driver: "json-file"
   options:
@@ -175,7 +175,7 @@ services:
     environment:
       - CURRENCY_SERVICE_PORT
       - OTEL_EXPORTER_OTLP_ENDPOINT
-      - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES},service.name=currencyservice   # The C++ SDK does not support OTEL_SERVICE_NAME
+      - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES},service.name=currencyservice # The C++ SDK does not support OTEL_SERVICE_NAME
     depends_on:
       otelcol:
         condition: service_started
@@ -232,7 +232,15 @@ services:
       - OTEL_SERVICE_NAME=featureflagservice
       - DATABASE_URL=ecto://ffs:ffs@ffs_postgres:5432/ffs
     healthcheck:
-      test: ["CMD", "curl", "-H", "baggage: synthetic_request=true", "-f", "http://localhost:${FEATURE_FLAG_SERVICE_PORT}"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-H",
+          "baggage: synthetic_request=true",
+          "-f",
+          "http://localhost:${FEATURE_FLAG_SERVICE_PORT}",
+        ]
     depends_on:
       ffs_postgres:
         condition: service_healthy
@@ -447,7 +455,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 500M               # This is high to enable supporting the recommendationCache feature flag use case
+          memory: 500M # This is high to enable supporting the recommendationCache feature flag use case
     restart: unless-stopped
     ports:
       - "${RECOMMENDATION_SERVICE_PORT}"
@@ -597,7 +605,6 @@ services:
       - "${REDIS_PORT}"
     logging: *logging
 
-
   # ********************
   # Telemetry Components
   # ********************
@@ -677,7 +684,11 @@ services:
         limits:
           memory: 125M
     restart: unless-stopped
-    command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
+    command:
+      [
+        "--config=/etc/otelcol-config.yml",
+        "--config=/etc/otelcol-config-extras.yml",
+      ]
     volumes:
       - ./src/otelcollector/otelcol-config.yml:/etc/otelcol-config.yml
       - ./src/otelcollector/otelcol-config-extras.yml:/etc/otelcol-config-extras.yml
@@ -745,7 +756,13 @@ services:
     expose:
       - "9200"
     healthcheck:
-      test: ["CMD", "curl", "-f", "https://localhost:9200/_cluster/health?wait_for_status=yellow"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "https://localhost:9200/_cluster/health?wait_for_status=yellow",
+        ]
       interval: 20s
       timeout: 10s
       retries: 10
@@ -755,11 +772,19 @@ services:
     image: opensearchproject/data-prepper:latest
     container_name: dataprepper
     volumes:
-      - ./src/dataprepper/pipelines.yaml:/usr/share/data-prepper/pipelines/trace_analytics_no_ssl_2x.yml
+      - /data/service-map/
+      - ./src/dataprepper/trace_analytics_no_ssl_2x.yml:/usr/share/data-prepper/pipelines/trace_analytics_no_ssl_2x.yml
+      - ./src/dataprepper/pipelines.yaml:/usr/share/data-prepper/pipelines/pipelines.yaml
       - ./src/dataprepper/data-prepper-config.yaml:/usr/share/data-prepper/config/data-prepper-config.yaml
     ports:
-      - "21892"
+      - "21890:21890"
+      - "21891:21891"
+    expose:
+      - "21890"
+      - "21891"
     logging: *logging
+    depends_on:
+      - opensearch
 
   # OpenSearch store - dashboard
   opensearch-dashboards:

--- a/src/dataprepper/pipelines.yaml
+++ b/src/dataprepper/pipelines.yaml
@@ -4,7 +4,10 @@
 demo-pipeline:
   source:
     otel_logs_source:
+      port: 21891
       ssl: false
+      authentication:
+        unauthenticated:
   sink:
     - opensearch:
         hosts: ["https://opensearch:9200"]

--- a/src/dataprepper/trace_analytics_no_ssl_2x.yml
+++ b/src/dataprepper/trace_analytics_no_ssl_2x.yml
@@ -16,7 +16,7 @@ raw-pipeline:
     pipeline:
       name: "entry-pipeline"
   processor:
-    - otel_trace_raw:
+    - otel_traces:
   sink:
     - opensearch:
         hosts: ["https://opensearch:9200"]
@@ -30,7 +30,7 @@ service-map-pipeline:
     pipeline:
       name: "entry-pipeline"
   processor:
-    - service_map_stateful:
+    - service_map:
   sink:
     - opensearch:
         hosts: ["https://opensearch:9200"]

--- a/src/dataprepper/trace_analytics_no_ssl_2x.yml
+++ b/src/dataprepper/trace_analytics_no_ssl_2x.yml
@@ -2,7 +2,10 @@ entry-pipeline:
   delay: "100"
   source:
     otel_trace_source:
+      port: 21890
       ssl: false
+      authentication:
+        unauthenticated:
   sink:
     - pipeline:
         name: "raw-pipeline"
@@ -16,7 +19,7 @@ raw-pipeline:
     - otel_trace_raw:
   sink:
     - opensearch:
-        hosts: [ "https://opensearch:9200" ]
+        hosts: ["https://opensearch:9200"]
         insecure: true
         username: "admin"
         password: "admin"
@@ -38,7 +41,7 @@ service-map-pipeline:
 trace-error-metrics-pipeline:
   source:
     pipeline:
-      name: "span-pipeline"
+      name: "raw-pipeline"
   processor:
     - aggregate:
         identification_keys: ["serviceName", "traceId"]
@@ -54,31 +57,31 @@ trace-error-metrics-pipeline:
         password: "admin"
         index: trace-error-metrics
 trace-high-latency-metrics-pipeline:
-    source:
-      pipeline:
-        name: "span-pipeline"
-    processor:
-      - aggregate:
-          identification_keys: ["serviceName", "traceId"]
-          action:
-            histogram:
-              key: "durationInNaos"
-              record_minmax: true
-              units: "nanoseconds"
-              buckets: [1000000000, 1500000000, 2000000000]
-          group_duration: "20s"
-          aggregate_when: "/durationInNanos > 1000000000"
-    sink:
-      - opensearch:
-          hosts: ["https://opensearch:9200"]
-          insecure: true
-          username: "admin"
-          password: "admin"
-          index: trace-high-latency-metrics
+  source:
+    pipeline:
+      name: "raw-pipeline"
+  processor:
+    - aggregate:
+        identification_keys: ["serviceName", "traceId"]
+        action:
+          histogram:
+            key: "durationInNaos"
+            record_minmax: true
+            units: "nanoseconds"
+            buckets: [1000000000, 1500000000, 2000000000]
+        group_duration: "20s"
+        aggregate_when: "/durationInNanos > 1000000000"
+  sink:
+    - opensearch:
+        hosts: ["https://opensearch:9200"]
+        insecure: true
+        username: "admin"
+        password: "admin"
+        index: trace-high-latency-metrics
 trace-normal-pipeline:
   source:
     pipeline:
-      name: "span-pipeline"
+      name: "raw-pipeline"
   processor:
     - aggregate:
         identification_keys: ["serviceName"]

--- a/src/otelcollector/otelcol-config.yml
+++ b/src/otelcollector/otelcol-config.yml
@@ -1,7 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-
 receivers:
   otlp:
     protocols:
@@ -18,8 +17,13 @@ exporters:
     endpoint: "jaeger:4317"
     tls:
       insecure: true
+  otlp/traces:
+    endpoint: "data-prepper:21890"
+    tls:
+      insecure: true
+      insecure_skip_verify: true
   otlp/logs:
-    endpoint: "dataprepper:21892"
+    endpoint: "data-prepper:21891"
     tls:
       insecure: true
       insecure_skip_verify: true
@@ -54,7 +58,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp, debug, spanmetrics, otlp/logs]
+      exporters: [otlp, debug, spanmetrics, otlp/traces]
     metrics:
       receivers: [otlp, spanmetrics]
       processors: [filter/ottl, transform, batch]


### PR DESCRIPTION
# Changes

Fixed [102](https://github.com/opensearch-project/opentelemetry-demo/issues/102) issue with incorrectly mapped data-prepper service volume for trace analysis to support trace analytics via Data prepper

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [X] `CHANGELOG.md` updated to document new feature additions
* [X] Appropriate documentation updates in the [docs][]
* [X] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
