### PR TITLE
update add serviceName keyword default field to exemplar fields

### DIFF
--- a/src/dataprepper/pipelines.yaml
+++ b/src/dataprepper/pipelines.yaml
@@ -84,271 +84,298 @@ otel-metrics-pipeline:
         bulk_size: 4
         template_type: index-template
         template_content: >
-          { "template": {
-            "mappings": {
-              "_meta": {
-                "version": "1.0.0",
-                "catalog": "observability",
-                "type": "metrics",
-                "component": "metrics",
-                "correlations" : [
+          {
+            "index_patterns": [
+              "ss4o_metrics-*-*"
+            ],
+            "template": {
+              "mappings": {
+                "_meta": {
+                  "version": "1.0.0",
+                  "catalog": "observability",
+                  "type": "metrics",
+                  "component": "metrics",
+                  "correlations" : [
+                    {
+                      "field": "spanId",
+                      "foreign-schema" : "traces",
+                      "foreign-field" : "spanId"
+                    },
+                    {
+                      "field": "traceId",
+                      "foreign-schema" : "traces",
+                      "foreign-field" : "traceId"
+                    }
+                  ]
+                },
+                "_source": {
+                  "enabled": true
+                },
+                "dynamic_templates": [
                   {
-                    "field": "spanId",
-                    "foreign-schema" : "traces",
-                    "foreign-field" : "spanId"
+                    "exemplar_attributes_map": {
+                      "mapping": {
+                        "type": "keyword"
+                      },
+                      "path_match": "exemplar.attributes.*"
+                    }
                   },
                   {
-                    "field": "traceId",
-                    "foreign-schema" : "traces",
-                    "foreign-field" : "traceId"
+                    "instrumentation_scope_attributes_map": {
+                      "mapping": {
+                        "type": "keyword"
+                      },
+                      "path_match": "instrumentationScope.attributes.*"
+                    }
                   }
-                ]
-              },
-              "_source": {
-                "enabled": true
-              },
-              "dynamic_templates": [
-                {
-                  "exemplar_attributes_map": {
-                    "mapping": {
-                      "type": "keyword"
-                    },
-                    "path_match": "exemplar.attributes.*"
-                  }
-                },
-                {
-                  "instrumentation_scope_attributes_map": {
-                    "mapping": {
-                      "type": "keyword"
-                    },
-                    "path_match": "instrumentationScope.attributes.*"
-                  }
-                }
-              ],
-              "properties": {
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                },
-                "attributes": {
-                  "type": "object",
-                  "properties": {
-                    "data_stream": {
-                      "properties": {
-                        "dataset": {
-                          "ignore_above": 128,
-                          "type": "keyword"
-                        },
-                        "namespace": {
-                          "ignore_above": 128,
-                          "type": "keyword"
-                        },
-                        "type": {
-                          "ignore_above": 56,
-                          "type": "keyword"
+                ],
+                "properties": {
+                  "serviceName": {
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  },
+                  "attributes": {
+                    "type": "object",
+                    "properties": {
+                      "data_stream": {
+                        "properties": {
+                          "dataset": {
+                            "ignore_above": 128,
+                            "type": "keyword"
+                          },
+                          "namespace": {
+                            "ignore_above": 128,
+                            "type": "keyword"
+                          },
+                          "type": {
+                            "ignore_above": 56,
+                            "type": "keyword"
+                          }
                         }
                       }
                     }
-                  }
-                },
-                "description": {
-                  "type": "text",
-                  "fields": {
-                    "keyword": {
-                      "type": "keyword",
-                      "ignore_above": 256
+                  },
+                  "description": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
                     }
-                  }
-                },
-                "unit": {
-                  "type": "keyword",
-                  "ignore_above": 128
-                },
-                "kind": {
-                  "type": "keyword",
-                  "ignore_above": 128
-                },
-                "aggregationTemporality": {
-                  "type": "keyword",
-                  "ignore_above": 128
-                },
-                "monotonic": {
-                  "type": "boolean"
-                },
-                "startTime": {
-                  "type": "date"
-                },
-                "@timestamp": {
-                  "type": "date"
-                },
-                "observedTimestamp": {
-                  "type": "date_nanos"
-                },
-                "value@int": {
-                  "type": "integer"
-                },
-                "value@double": {
-                  "type": "double"
-                },
-                "buckets": {
-                  "type" : "nested",
-                  "properties": {
-                    "count": {
-                      "type": "long"
-                    },
-                    "sum": {
-                      "type": "double"
-                    },
-                    "max": {
-                      "type": "float"
-                    },
-                    "min": {
-                      "type": "float"
+                  },
+                  "unit": {
+                    "type": "keyword",
+                    "ignore_above": 128
+                  },
+                  "kind": {
+                    "type": "keyword",
+                    "ignore_above": 128
+                  },
+                  "aggregationTemporality": {
+                    "type": "keyword",
+                    "ignore_above": 128
+                  },
+                  "monotonic": {
+                    "type": "boolean"
+                  },
+                  "startTime": {
+                    "type": "date"
+                  },
+                  "@timestamp": {
+                    "type": "date"
+                  },
+                  "observedTimestamp": {
+                    "type": "date_nanos"
+                  },
+                  "value@int": {
+                    "type": "integer"
+                  },
+                  "value@double": {
+                    "type": "double"
+                  },
+                  "buckets": {
+                    "type" : "nested",
+                    "properties": {
+                      "count": {
+                        "type": "long"
+                      },
+                      "sum": {
+                        "type": "double"
+                      },
+                      "max": {
+                        "type": "float"
+                      },
+                      "min": {
+                        "type": "float"
+                      }
                     }
-                  }
-                },
-                "bucketCount": {
-                  "type": "long"
-                },
-                "bucketCountsList": {
-                  "type": "long"
-                },
-                "explicitBoundsList": {
-                  "type": "float"
-                },
-                "explicitBoundsCount": {
-                  "type": "float"
-                },
-                "quantiles": {
-                  "properties": {
-                    "quantile": {
-                      "type": "double"
-                    },
-                    "value": {
-                      "type": "double"
+                  },
+                  "bucketCount": {
+                    "type": "long"
+                  },
+                  "bucketCountsList": {
+                    "type": "long"
+                  },
+                  "explicitBoundsList": {
+                    "type": "float"
+                  },
+                  "explicitBoundsCount": {
+                    "type": "float"
+                  },
+                  "quantiles": {
+                    "properties": {
+                      "quantile": {
+                        "type": "double"
+                      },
+                      "value": {
+                        "type": "double"
+                      }
                     }
-                  }
-                },
-                "quantileValuesCount": {
-                  "type": "long"
-                },
-                "positiveBuckets": {
-                  "type" : "nested",
-                  "properties": {
-                    "count": {
-                      "type": "long"
-                    },
-                    "max": {
-                      "type": "float"
-                    },
-                    "min": {
-                      "type": "float"
+                  },
+                  "quantileValuesCount": {
+                    "type": "long"
+                  },
+                  "positiveBuckets": {
+                    "type" : "nested",
+                    "properties": {
+                      "count": {
+                        "type": "long"
+                      },
+                      "max": {
+                        "type": "float"
+                      },
+                      "min": {
+                        "type": "float"
+                      }
                     }
-                  }
-                },
-                "negativeBuckets": {
-                  "type" : "nested",
-                  "properties": {
-                    "count": {
-                      "type": "long"
-                    },
-                    "max": {
-                      "type": "float"
-                    },
-                    "min": {
-                      "type": "float"
+                  },
+                  "negativeBuckets": {
+                    "type" : "nested",
+                    "properties": {
+                      "count": {
+                        "type": "long"
+                      },
+                      "max": {
+                        "type": "float"
+                      },
+                      "min": {
+                        "type": "float"
+                      }
                     }
-                  }
-                },
-                "negativeOffset": {
-                  "type": "integer"
-                },
-                "positiveOffset": {
-                  "type": "integer"
-                },
-                "zeroCount": {
-                  "type": "long"
-                },
-                "scale": {
-                  "type": "long"
-                },
-                "max": {
-                  "type": "float"
-                },
-                "min": {
-                  "type": "float"
-                },
-                "sum": {
-                  "type": "float"
-                },
-                "count": {
-                  "type": "long"
-                },
-                "exemplar": {
-                  "properties": {
-                    "time": {
-                      "type": "date"
-                    },
-                    "traceId": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    },
-                    "serviceName": {
-                      "ignore_above": 256,
-                      "type": "keyword"
-                    },
-                    "spanId": {
-                      "ignore_above": 256,
-                      "type": "keyword"
+                  },
+                  "negativeOffset": {
+                    "type": "integer"
+                  },
+                  "positiveOffset": {
+                    "type": "integer"
+                  },
+                  "zeroCount": {
+                    "type": "long"
+                  },
+                  "scale": {
+                    "type": "long"
+                  },
+                  "max": {
+                    "type": "float"
+                  },
+                  "min": {
+                    "type": "float"
+                  },
+                  "sum": {
+                    "type": "float"
+                  },
+                  "count": {
+                    "type": "long"
+                  },
+                  "exemplar": {
+                    "properties": {
+                      "time": {
+                        "type": "date"
+                      },
+                      "traceId": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      },
+                      "serviceName": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      },
+                      "spanId": {
+                        "ignore_above": 256,
+                        "type": "keyword"
+                      }
                     }
-                  }
-                },
-                "instrumentationScope": {
-                  "properties": {
-                    "name": {
-                      "type": "keyword",
-                      "ignore_above": 256
-                    },
-                    "version": {
-                      "type": "keyword",
-                      "ignore_above": 256
-                    },
-                    "droppedAttributesCount": {
-                      "type": "integer"
-                    },
-                    "schemaUrl": {
-                      "type": "text",
-                      "fields": {
-                        "keyword": {
-                          "type": "keyword",
-                          "ignore_above": 256
+                  },
+                  "instrumentationScope": {
+                    "properties": {
+                      "name": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      },
+                      "version": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      },
+                      "droppedAttributesCount": {
+                        "type": "integer"
+                      },
+                      "schemaUrl": {
+                        "type": "text",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                          }
                         }
                       }
                     }
-                  }
-                },
-                "schemaUrl": {
-                  "type": "text",
-                  "fields": {
-                    "keyword": {
-                      "type": "keyword",
-                      "ignore_above": 256
+                  },
+                  "schemaUrl": {
+                    "type": "text",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                      }
                     }
                   }
                 }
+              },
+              "aliases" : {
+                "otel-metrics-" : {}
+              },
+              "settings": {
+                "index": {
+                  "mapping": {
+                    "total_fields": {
+                      "limit": 10000
+                    }
+                  },
+                  "refresh_interval": "5s"
+                }
               }
             },
-            "aliases" : {
-              "otel-metrics-" : {}
-            },
-            "settings": {
-              "index": {
-                "mapping": {
-                  "total_fields": {
-                    "limit": 10000
-                  }
+            "composed_of": [],
+            "version": 1,
+            "_meta": {
+              "description": "Observability Metrics Mapping Template",
+              "catalog": "observability",
+              "type": "metrics",
+              "correlations" : [
+                {
+                  "field": "spanId",
+                  "foreign-schema" : "traces",
+                  "foreign-field" : "spanId"
                 },
-                "refresh_interval": "5s"
-              }
+                {
+                  "field": "traceId",
+                  "foreign-schema" : "traces",
+                  "foreign-field" : "traceId"
+                }
+              ]
             }
-          }}
+          }

--- a/src/dataprepper/pipelines.yaml
+++ b/src/dataprepper/pipelines.yaml
@@ -293,6 +293,10 @@ otel-metrics-pipeline:
                       "ignore_above": 256,
                       "type": "keyword"
                     },
+                    "serviceName": {
+                      "ignore_above": 256,
+                      "type": "keyword"
+                    },
                     "spanId": {
                       "ignore_above": 256,
                       "type": "keyword"

--- a/src/dataprepper/templates/ss4o_metrics.json
+++ b/src/dataprepper/templates/ss4o_metrics.json
@@ -211,6 +211,10 @@
               "ignore_above": 256,
               "type": "keyword"
             },
+            "serviceName": {
+              "ignore_above": 256,
+              "type": "keyword"
+            },
             "spanId": {
               "ignore_above": 256,
               "type": "keyword"

--- a/src/dataprepper/templates/ss4o_metrics.json
+++ b/src/dataprepper/templates/ss4o_metrics.json
@@ -44,6 +44,9 @@
         }
       ],
       "properties": {
+        "serviceName": {
+          "type": "keyword"
+        },
         "name": {
           "type": "keyword",
           "ignore_above": 256
@@ -290,4 +293,3 @@
     ]
   }
 }
-


### PR DESCRIPTION
# Changes

update data-prepper's metrics index template with serviceName field under exemplar section:
```
      "exemplar": {
          "properties": {
            "time": {
              "type": "date"
            },
            "traceId": {
              "ignore_above": 256,
              "type": "keyword"
            },
            "serviceName": {
              "ignore_above": 256,
              "type": "keyword"
            },
            "spanId": {
              "ignore_above": 256,
              "type": "keyword"
            }
          }
        } 
```
# related issues
https://github.com/opensearch-project/opentelemetry-demo/issues/147
# additional context
[exemplar proto](https://github.com/open-telemetry/opentelemetry-proto/blob/bd7cf55b6d45f3c587d2131b68a7e5a501bdb10c/opentelemetry/proto/metrics/v1/metrics.proto#L660)