### PR TITLE
fix discussions url to wrong repository in question.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,4 +6,4 @@ labels: question
 
 # Question
 
-Use [Github Discussions](https://github.com/open-telemetry/opentelemetry-demo/discussions/).
+Use [Github Discussions](https://github.com/opensearch-project/opentelemetry-demo/discussions/).


### PR DESCRIPTION
# Changes

Fixed the url in the question.md issue template, that pointed to a diffrent repository.

fixes #158