### PR TITLE
update OTel logs index to support OpenSearch metrics UI

### DIFF
--- a/src/dataprepper/pipelines.yaml
+++ b/src/dataprepper/pipelines.yaml
@@ -16,7 +16,7 @@ otel-logs-pipeline:
         password: "my_%New%_passW0rd!@#"
         insecure: true
         index_type: custom
-        index: otel-events-%{yyyy.MM.dd}
+        index: ss4o_logs-%{yyyy.MM.dd}
         bulk_size: 4
 
 entry-pipeline:
@@ -37,8 +37,8 @@ raw-pipeline:
     - otel_trace_raw:
   sink:
     - opensearch:
-        hosts: [ "https://opensearch-node1:9200" ]
-        insecure: true        
+        hosts: ["https://opensearch-node1:9200"]
+        insecure: true
         username: "admin"
         password: "my_%New%_passW0rd!@#"
         index_type: trace-analytics-raw


### PR DESCRIPTION
# Changes

update OTel logs index to support OpenSearch metrics UI

This Pull request modifies the `src/dataprepper/pipelines.yaml` to adhere to ss4o_logs index defined in the simple schema for Observability.

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
